### PR TITLE
Style fix

### DIFF
--- a/public/datasetConfig.json
+++ b/public/datasetConfig.json
@@ -258,7 +258,8 @@
        },
        {
          "name":"HCP",
-         "prefix":"https://open-neurodata.s3.amazonaws.com/rokem/hcp1200"
+         "prefix":"https://open-neurodata.s3.amazonaws.com/rokem/hcp1200",
+         "participantList":"/afq/participants.tsv"
       }
     ],
     "default":{

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script setup>
+import ToolTip from './components/ToolTip.vue'
 import DatasetSelect from './components/DatasetSelect.vue';
 import ListSelect from './components/ListSelect.vue';
 import NiivueRender from './components/NiivueRender.vue';

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,8 +103,6 @@ async function updateScans(){
       output.push(item)
     }
   }
-  return output
-
   if(output.length < 1){
     throw new Error("no scans exist for subject",{value:subject.value})
   }
@@ -142,6 +140,9 @@ async function updateBundles(){
   }
   return output
 }
+watch(dataset, (newVal) => {
+  initalizeSubjectList()
+})
 
 watch(subject, async (newVal) => {
   if(newVal){

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,5 @@
 <template>
-<div id = "menu">
-  <DatasetSelect :datasets="datasets" v-model:dataset="dataset" />
-  <SubjectSelect :subjectList="subjectList" v-model:subject="subject"/>
-  <ListSelect v-if="showSiteSelect" v-model:value="site" :list="sites"/>
-  <div v-if="!showSiteSelect">site: {{ sites[0] }}</div>
-  <ListSelect v-model:value="scan" :list="scans"/>
-  <BundleSelect v-model:selectedBundles="selectedBundles" :bundles="bundles"/>
-</div>
-<div id="niivue">
+<div id = "app">
   <NiivueRender
   :dataset="dataset"
   :subject="subject"
@@ -15,6 +7,14 @@
   :scan="scan"
   :bundles="selectedBundles"
   />
+  <div class = "vertical-menu">
+    <DatasetSelect :datasets="datasets" v-model:dataset="dataset" />
+    <SubjectSelect :subjectList="subjectList" v-model:subject="subject"/>
+    <ListSelect v-if="showSiteSelect" v-model:value="site" :list="sites"/>
+    <div v-if="!showSiteSelect">site: {{ sites[0] }}</div>
+    <ListSelect v-model:value="scan" :list="scans"/>
+    <BundleSelect v-model:selectedBundles="selectedBundles" :bundles="bundles"/>
+  </div>
 </div>
 </template>
 
@@ -172,17 +172,30 @@ watch(subject, async (newVal) => {
 </script>
 
 <style>
+#app{
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+}
 #niivue{
   height: 80vh;
   width: 96vw;
   margin: auto;
 }
-#menu{
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.vertical-menu{
+  display: grid;
+  justify-content: left;
+  align-items: left;
+  align-content: start;
+  width: 100vw;
+  padding: 10px;
 }
-#menu > * {
-    padding: 10px 10px;      /* Adds some padding to each child item */
+.vertical-menu > * {
+    padding-bottom: 20px;
+}
+
+.vertical-menu > *:last-child {
+    padding-bottom: 0;
 }
 </style>

--- a/src/components/BundleSelect.vue
+++ b/src/components/BundleSelect.vue
@@ -16,12 +16,6 @@ const props = defineProps({
     bundles: {
         type: Array,
         required: true,
-        // validator: (value) => {         // validator not currently working
-        //     value.every(element => {
-        //         console.log(element.name)
-        //         return element.hasOwnProperty('name')
-        //     })
-        // }
     },
     selectedBundles: {type:Array,
         required:true

--- a/src/components/NiivueRender.vue
+++ b/src/components/NiivueRender.vue
@@ -4,11 +4,6 @@ import {onMounted,ref,watch} from 'vue';
 import { checkLink, getVolumeLink, getBundleLink } from '../utilites/DatasetLogic';
 
 const props = defineProps({
-    // subject: {type: Object, required: true,
-    //     validator: (value) => {
-    //         return value.hasOwnProperty('id') && value.hasOwnProperty('site')
-    //     }
-    // },
     subject: {},
     dataset:{
         type:Object,
@@ -22,13 +17,6 @@ const props = defineProps({
         required: false
     },
     scan: {},
-    // scan:{
-    //     type: String,
-    //     required: true,
-    //     validator: (value) => {
-    //         return value.every(element => element.hasOwnProperty('fileName'))
-    //     }
-    // },
     site:{
         type: String,
         required: false,
@@ -102,6 +90,7 @@ function downloadNifti(){
         throw new Error("volumeLink failed check, likely does not exist",{value: volumeLink})
     }
 }
+
 //must be cleaner way to watch multiple objects?
 watch(() => props.subject, () => {
     updateVolume()

--- a/src/components/NiivueRender.vue
+++ b/src/components/NiivueRender.vue
@@ -123,7 +123,9 @@ watch(() => props.bundles, () => {
 </script>
 
 <template>
-    <canvas id="gl"></canvas>
+    <div id = "canvas">
+        <canvas id="gl">Your system doesn't support canvas</canvas>
+    </div>
     <div>C = Cycle Clip Plane | V = Cycle Slice Type | H,L,J,K = rotation | Scroll = move clip plane | Right Click = rotate clip plain | Left Click = rotate camera | Zoom:
         <input type="range" min="0.01" max="0.5" step="0.01" class="slider" v-model="zoom" @input="changeZoom"/>
         <button id="download" @click = "downloadNifti" >Download NIFTI file</button> </div>
@@ -133,7 +135,8 @@ watch(() => props.bundles, () => {
 #download{
     float: right;
 }
-#gl{
-    border: 1px solid black;
+#canvas{
+    width: 100vh;
+    height: 80vh;
 }
 </style>

--- a/src/components/NiivueRender.vue
+++ b/src/components/NiivueRender.vue
@@ -114,32 +114,37 @@ watch(() => props.bundles, () => {
 </script>
 
 <template>
-    <div id = "canvas-container">
-        <canvas id="gl">Your system doesn't support canvas</canvas>
-    </div>
-    <div class="bottom-bar">
-        <div class="tooltip">
-            <ToolTip :tip="tip">Controls</ToolTip>
+    <div id="app">
+        <div id = "canvas-container">
+            <canvas id="gl">Your system doesn't support canvas</canvas>
         </div>
-        <div class="zoom">
-                Zoom: <input type="range" min="0.01" max="0.5" step="0.01" class="slider" v-model="zoom" @input="changeZoom"/>
+        <div class="bottom-bar">
+            <div class="tooltip">
+                <ToolTip :tip="tip">Controls</ToolTip>
+            </div>
+            <div class="zoom">
+                    Zoom: <input type="range" min="0.01" max="0.5" step="0.01" v-model="zoom" @input="changeZoom"/>
+            </div>
+            <button id="download" @click = "downloadNifti" >Download NIFTI file</button>
         </div>
-        <button id="download" @click = "downloadNifti" >Download NIFTI file</button>
     </div>
 </template>
 
 <style scoped>
-#download{
-    float: right;
+#app{
+    display: grid;
 }
 #canvas-container{
-    width: 100vh;
-    height: 80vh;
+    width: 110vh;
+    height: 95vh;
 }
 #gl{
+    align-self: left;
     border: black 1px solid;
 }
-#bottom-bar{
-    display: inline;
+.bottom-bar{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 </style>

--- a/src/components/NiivueRender.vue
+++ b/src/components/NiivueRender.vue
@@ -28,7 +28,7 @@ var zoom = 0.1
 
 function loadVolume(volumeLink){
     nv = new Niivue(({show3Dcrosshair: true, backColor: [1, 1, 1, 1]}))
-    nv.setSliceType(nv.sliceTypeRender)
+    nv.setSliceType(nv.sliceTypeMultiplanar);
     nv.attachTo('gl')
     nv.setClipPlane([-0.1, 270, 0])
     const volumeList = [
@@ -112,7 +112,7 @@ watch(() => props.bundles, () => {
 </script>
 
 <template>
-    <div id = "canvas">
+    <div id = "canvas-container">
         <canvas id="gl">Your system doesn't support canvas</canvas>
     </div>
     <div>C = Cycle Clip Plane | V = Cycle Slice Type | H,L,J,K = rotation | Scroll = move clip plane | Right Click = rotate clip plain | Left Click = rotate camera | Zoom:
@@ -124,8 +124,11 @@ watch(() => props.bundles, () => {
 #download{
     float: right;
 }
-#canvas{
+#canvas-container{
     width: 100vh;
     height: 80vh;
+}
+#gl{
+    border: black 1px solid;
 }
 </style>

--- a/src/components/NiivueRender.vue
+++ b/src/components/NiivueRender.vue
@@ -136,7 +136,7 @@ watch(() => props.bundles, () => {
 }
 #canvas-container{
     width: 110vh;
-    height: 95vh;
+    height: 93vh;
 }
 #gl{
     align-self: left;

--- a/src/components/NiivueRender.vue
+++ b/src/components/NiivueRender.vue
@@ -1,4 +1,5 @@
 <script setup>
+import ToolTip from './ToolTip.vue';
 import {Niivue} from '@niivue/niivue'
 import {onMounted,ref,watch} from 'vue';
 import { checkLink, getVolumeLink, getBundleLink } from '../utilites/DatasetLogic';
@@ -25,6 +26,7 @@ const props = defineProps({
 
 var nv = null
 var zoom = 0.1
+const tip = "C = Cycle Clip Plane | V = Cycle Slice Type | H,L,J,K = rotation | Scroll = move clip plane | Right Click = rotate clip plain | Left Click = rotate camera"
 
 function loadVolume(volumeLink){
     nv = new Niivue(({show3Dcrosshair: true, backColor: [1, 1, 1, 1]}))
@@ -115,9 +117,15 @@ watch(() => props.bundles, () => {
     <div id = "canvas-container">
         <canvas id="gl">Your system doesn't support canvas</canvas>
     </div>
-    <div>C = Cycle Clip Plane | V = Cycle Slice Type | H,L,J,K = rotation | Scroll = move clip plane | Right Click = rotate clip plain | Left Click = rotate camera | Zoom:
-        <input type="range" min="0.01" max="0.5" step="0.01" class="slider" v-model="zoom" @input="changeZoom"/>
-        <button id="download" @click = "downloadNifti" >Download NIFTI file</button> </div>
+    <div class="bottom-bar">
+        <div class="tooltip">
+            <ToolTip :tip="tip">Controls</ToolTip>
+        </div>
+        <div class="zoom">
+                Zoom: <input type="range" min="0.01" max="0.5" step="0.01" class="slider" v-model="zoom" @input="changeZoom"/>
+        </div>
+        <button id="download" @click = "downloadNifti" >Download NIFTI file</button>
+    </div>
 </template>
 
 <style scoped>
@@ -130,5 +138,8 @@ watch(() => props.bundles, () => {
 }
 #gl{
     border: black 1px solid;
+}
+#bottom-bar{
+    display: inline;
 }
 </style>

--- a/src/components/SearchableListSelect.vue
+++ b/src/components/SearchableListSelect.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class = "search-select">
       <input v-model="searchQuery" placeholder="Search Subjects..." @input="filterList" />
       <select v-model="selected">
         <option v-for="item in filteredList" :value="item">
@@ -37,3 +37,12 @@ const filteredList = computed({
     }
 })
 </script>
+
+<style scoped>
+.search-select {
+    display: flex;
+    flex-direction: column;
+    gap: 0px;
+    width: 200px;
+}
+</style>

--- a/src/components/SearchableListSelect.vue
+++ b/src/components/SearchableListSelect.vue
@@ -16,13 +16,6 @@ const props = defineProps({
     list: {
         type: Array,
         required: true,
-        // validator: value => {
-        //     return value.every(item => {
-        //         if(typeof(item) == 'Object'){
-        //             return item.hasOwnAttribute('id')
-        //         }
-        //     })
-        // }
     },
     selected: {
         type: [String, Object],

--- a/src/components/ToolTip.vue
+++ b/src/components/ToolTip.vue
@@ -1,0 +1,39 @@
+<template>
+    <div class="tooltip"><slot />
+        <span class="tooltiptext">{{ props.tip }}</span>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({tip:{type:String,required:true}})
+</script>
+<style scoped>
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  width: 400px;
+  bottom: 100%;
+  left: 200%;
+  margin-left: -60px;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+</style>

--- a/src/utilites/DatasetLogic.js
+++ b/src/utilites/DatasetLogic.js
@@ -4,7 +4,8 @@ import * as d3 from 'd3'
 export async function updateSubjectList(dataset){
     if(dataset){
         if (dataset.hasOwnProperty('participantList')){
-            const x = await d3.tsv(dataset.prefix+dataset.participantList)
+            let link = dataset.prefix+dataset.participantList
+            const x = await d3.tsv(link)
             const subjectList = combindDuplicateSites(x)
             return subjectList
         }else{


### PR DESCRIPTION
This pull request adjusts the canvas width such that it is able to displays all 4 scans at once.

because we have made the canvas much more square, there is now room on the sides to put content. Considering putting the menu options on the right side of the scan instead of the top.

to do:
- [ ] fix bundle selection taking up space when many selections are made
