### PR TITLE
Preview and Deployment Fix

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,12 @@
-module.exports = {
-  publicPath: process.env.NODE_ENV === 'production'
-    ? '/tractoscope'
-    : '/'
+let publicPath = '/tractoscope';
+
+if (process.env.NODE_ENV !== 'production') {
+    publicPath = '/';
+} else if (process.env.DEPLOY_ENV === 'netlify') {
+    publicPath = '/';
 }
+
+module.exports = {
+  publicPath: publicPath
+}
+


### PR DESCRIPTION
We can create a new environment variable called DEPLOY_ENV and then set it to netlify in the netlify configuration. We can then check that variable and set the default path to "/" if DEPLOY_ENV == "netlify". 